### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,79 +1,81 @@
 #!/usr/bin/env python
 import os, sys, subprocess, platform, sysconfig
-import mpi4py
-import numpy as np
-from distutils.core import setup, Extension
+from setuptools import setup
+from setuptools.extension import Extension
 from distutils.command import build_ext
-from os.path import exists, abspath, dirname, join
 
 cmake_cmd_args = []
 for f in sys.argv:
-    if f.startswith('-D'):
+    if f.startswith("-D"):
         cmake_cmd_args.append(f)
 
+
 class CMakeExtension(Extension):
-    def __init__(self, name, target='all', cmake_lists_dir='.', **kwa):
+    def __init__(self, name, target="all", cmake_lists_dir=".", **kwa):
         Extension.__init__(self, name, sources=[], **kwa)
         self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
         self.target = target
+
 
 class cmake_build_ext(build_ext.build_ext):
     def build_extensions(self):
         # Ensure that CMake is present and working
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output(["cmake", "--version"])
         except OSError:
-            raise RuntimeError('Cannot find CMake executable')
+            raise RuntimeError("Cannot find CMake executable")
 
-        options = { 'debug_build': False, 
-                    'HDF5_ROOT': False,
-                    'JEMALLOC_ROOT': False }
+        options = {"debug_build": False, "HDF5_ROOT": False, "JEMALLOC_ROOT": False}
 
-        if os.environ.get('NEUROH5_DEBUG', False):
-            options['debug_build'] = True
-        if os.environ.get('HDF5_ROOT', False):
-            options['HDF5_ROOT'] = os.environ.get('HDF5_ROOT')
-        if os.environ.get('JEMALLOC_ROOT', False):
-            options['JEMALLOC_ROOT'] = os.environ.get('JEMALLOC_ROOT')
-            
-            
+        if os.environ.get("NEUROH5_DEBUG", False):
+            options["debug_build"] = True
+        if os.environ.get("HDF5_ROOT", False):
+            options["HDF5_ROOT"] = os.environ.get("HDF5_ROOT")
+        if os.environ.get("JEMALLOC_ROOT", False):
+            options["JEMALLOC_ROOT"] = os.environ.get("JEMALLOC_ROOT")
+
         for ext in self.extensions:
 
             extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-            cfg = 'Debug' if options.get('debug_build', False) else 'RelWithDebInfo'
+            cfg = "Debug" if options.get("debug_build", False) else "RelWithDebInfo"
 
             cmake_args = [
-                '-DCMAKE_BUILD_TYPE=%s' % cfg,
+                "-DCMAKE_BUILD_TYPE=%s" % cfg,
                 # Ask CMake to place the resulting library in the directory
                 # containing the extension
-                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir),
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir),
                 # Other intermediate static libraries are placed in a
                 # temporary build directory instead
-                '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), self.build_temp),
+                "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}".format(
+                    cfg.upper(), self.build_temp
+                ),
                 # Hint CMake to use the same Python executable that
                 # is launching the build, prevents possible mismatching if
                 # multiple versions of Python are installed
-                '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
+                "-DPYTHON_EXECUTABLE={}".format(sys.executable),
                 # Add other project-specific CMake arguments if needed
                 # ...
             ]
 
             # We can handle some platform-specific settings at our discretion
-            if platform.system() == 'Windows':
-                plat = ('x64' if platform.architecture()[0] == '64bit' else 'Win32')
+            if platform.system() == "Windows":
+                plat = "x64" if platform.architecture()[0] == "64bit" else "Win32"
                 cmake_args += [
                     # These options are likely to be needed under Windows
-                    '-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE',
-                    '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir),
+                    "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
+                    "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}".format(
+                        cfg.upper(), extdir
+                    ),
                 ]
                 # Assuming that Visual Studio and MinGW are supported compilers
-                if self.compiler.compiler_type == 'msvc':
+                if self.compiler.compiler_type == "msvc":
                     cmake_args += [
-                        '-DCMAKE_GENERATOR_PLATFORM=%s' % plat,
+                        "-DCMAKE_GENERATOR_PLATFORM=%s" % plat,
                     ]
                 else:
                     cmake_args += [
-                        '-G', 'MinGW Makefiles',
+                        "-G",
+                        "MinGW Makefiles",
                     ]
 
             python_config_vars = sysconfig.get_config_vars()
@@ -83,15 +85,15 @@ class cmake_build_ext(build_ext.build_ext):
             if mdt:
                 cmake_args.append("-DCMAKE_OSX_DEPLOYMENT_TARGET={}".format(mdt))
 
-            if options.get('HDF5_ROOT', False):
+            if options.get("HDF5_ROOT", False):
                 cmake_args += [
-                    '-DHDF5_ROOT=%s' % options.get('HDF5_ROOT'),
-                    ]
+                    "-DHDF5_ROOT=%s" % options.get("HDF5_ROOT"),
+                ]
 
-            if options.get('JEMALLOC_ROOT', False):
+            if options.get("JEMALLOC_ROOT", False):
                 cmake_args += [
-                    '-DJEMALLOC_ROOT_DIR=%s' % options.get('JEMALLOC_ROOT'),
-                    ]
+                    "-DJEMALLOC_ROOT_DIR=%s" % options.get("JEMALLOC_ROOT"),
+                ]
 
             cmake_args += cmake_cmd_args
 
@@ -99,39 +101,35 @@ class cmake_build_ext(build_ext.build_ext):
                 os.makedirs(self.build_temp)
 
             # Config
-            subprocess.check_call(['cmake', ext.cmake_lists_dir] + cmake_args,
-                                  cwd=self.build_temp)
+            subprocess.check_call(
+                ["cmake", ext.cmake_lists_dir] + cmake_args, cwd=self.build_temp
+            )
 
             # Build
-            subprocess.check_call(['cmake', '--build', '.', '--config', cfg, '--target', ext.target],
-                                  cwd=self.build_temp)
+            subprocess.check_call(
+                ["cmake", "--build", ".", "--config", cfg, "--target", ext.target],
+                cwd=self.build_temp,
+            )
 
 
 setup(
-    name='NeuroH5',
-    package_dir = {'': 'python'},
-    packages = ["neuroh5"],
-    version='0.1.4',
-    maintainer = "Ivan Raikov",
-    maintainer_email = "ivan.g.raikov@gmail.com",
-    description = "NeuroH5 library",
-    url = "http://github.com/iraikov/neuroh5",
+    name="NeuroH5",
+    package_dir={"": "python"},
+    packages=["neuroh5"],
+    version="0.1.4",
+    maintainer="Ivan Raikov",
+    maintainer_email="ivan.g.raikov@gmail.com",
+    description="NeuroH5 library",
+    url="http://github.com/iraikov/neuroh5",
     include_package_data=True,
-    install_requires=[
-        'click', 'h5py', 'numpy', 'mpi4py'
-    ],
-    entry_points='''
+    install_requires=["click", "h5py", "numpy", "mpi4py"],
+    entry_points="""
         [console_scripts]
         initrange=neuroh5.initrange:cli
         initprj=neuroh5.initprj:cli
         importdbs=neuroh5.importdbs:cli
         importcoords=neuroh5.importcoords:cli
-    ''',
-    cmdclass = {'build_ext': cmake_build_ext},
-    ext_modules = [
-        CMakeExtension('neuroh5.io', target='python_neuroh5_io')
-    ]
+    """,
+    cmdclass={"build_ext": cmake_build_ext},
+    ext_modules=[CMakeExtension("neuroh5.io", target="python_neuroh5_io")],
 )
-
-
-


### PR DESCRIPTION
This makes the package PEP517-compliant by adding a minimal pyproject.toml. This allows build-systems to detect the package meta-data and correctly infer the backend required to build and install the project. 